### PR TITLE
Pep8 cleanup and address deprecation warnings

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ requests>=2.21.0
 netCDF4>=1.5.1.2
 xarray>=0.12.3
 cfgrib>=0.9.7.1
+beautifulsoup4
+pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ xarray>=0.12.3
 cfgrib>=0.9.7.1
 beautifulsoup4
 pandas
+numpy

--- a/tests/test_hrrr.py
+++ b/tests/test_hrrr.py
@@ -1,5 +1,8 @@
 import os
 import unittest
+
+import numpy as np
+import pandas as pd
 from weather_forecast_retrieval import hrrr
 
 
@@ -17,14 +20,16 @@ def compare_gold(v_name, gold_dir, test_df):
 
     # read in the gold standard
     fp1 = os.path.join(gold_dir, v_name+'_data.csv')
-    dfgold = pd.read_csv(fp1, 'r', delimiter=',', parse_dates=['date_time'], dtype=pd.np.float32)
+    dfgold = pd.read_csv(
+        fp1, 'r', delimiter=',', parse_dates=['date_time'], dtype=np.float32
+    )
     dfgold.set_index('date_time', inplace=True)
 
     # see if they are the same
     # result = dfgold.equals(test_df)
-    result = pd.np.allclose(test_df.values,dfgold.values, atol=0)
+    result = np.allclose(test_df.values, dfgold.values, atol=0)
 
-    return  result
+    return result
 
 
 class TestHRRR(unittest.TestCase):
@@ -56,9 +61,8 @@ class TestHRRR(unittest.TestCase):
                                            'RME/gridded/hrrr_test/')
         self.force_zone_number = 11
 
-        self.output_path = os.path.join(self.test_dir,'RME','output')
-        self.gold = os.path.join(self.test_dir,'RME','gold','hrrr')
-
+        self.output_path = os.path.join(self.test_dir, 'RME', 'output')
+        self.gold = os.path.join(self.test_dir, 'RME', 'gold', 'hrrr')
 
     def testHRRRGribLoad(self):
         """
@@ -76,7 +80,9 @@ class TestHRRR(unittest.TestCase):
 
         df = pd.read_csv(os.path.join(self.gold, 'metadata.csv'))
         df.set_index('grid', inplace=True)
-        self.assertTrue(pd.np.allclose(df.values, metadata[df.columns].values, atol=0))
+        self.assertTrue(
+            np.allclose(df.values, metadata[df.columns].values, atol=0)
+        )
 
         # compare with the gold standard
         for k, df in data.items():

--- a/tests/test_hrrr.py
+++ b/tests/test_hrrr.py
@@ -1,7 +1,6 @@
+import os
 import unittest
 from weather_forecast_retrieval import hrrr
-import pandas as pd
-import os
 
 
 def compare_gold(v_name, gold_dir, test_df):

--- a/tests/test_hrrr.py
+++ b/tests/test_hrrr.py
@@ -10,7 +10,7 @@ def compare_gold(v_name, gold_dir, test_df):
     Args:
         v_name: Name with in the file contains
         gold_dir: Directory containing gold standard results
-        test_dir: Directory containing test results to be compared
+        test_df: Data frame containing test results to be compared
     Returns:
         Boolean: Whether the two images were the same
     """

--- a/tests/test_hrrr_archive.py
+++ b/tests/test_hrrr_archive.py
@@ -3,11 +3,14 @@
 
 """Tests for `weather_forecast_retrieval` package."""
 
-import unittest
-from weather_forecast_retrieval import hrrr, hrrr_archive
-import pandas as pd
 import os
 import shutil
+import unittest
+
+import numpy as np
+import pandas as pd
+
+from weather_forecast_retrieval import hrrr_archive
 
 
 def compare_gold(v_name, gold_dir, test_df):
@@ -24,13 +27,15 @@ def compare_gold(v_name, gold_dir, test_df):
 
     # read in the gold standard
     fp1 = os.path.join(gold_dir, v_name+'.csv')
-    dfgold = pd.read_csv(fp1, 'r', delimiter=',', parse_dates=['date_time'], dtype=pd.np.float32)
+    dfgold = pd.read_csv(
+        fp1, 'r', delimiter=',', parse_dates=['date_time'], dtype=np.float32
+    )
     dfgold.set_index('date_time', inplace=True)
 
     # see if they are the same
     result = dfgold.equals(test_df)
 
-    return  result
+    return result
 
 
 class TestHRRRArchive(unittest.TestCase):
@@ -84,7 +89,7 @@ class TestHRRRArchive(unittest.TestCase):
             self.output_path,
             forecasts=0
         )
-            
+
     def test_download_archive(self):
         """ Test downloading the archive data from UofU, could take around 8 minutes """
 

--- a/tests/test_hrrr_archive.py
+++ b/tests/test_hrrr_archive.py
@@ -20,7 +20,7 @@ def compare_gold(v_name, gold_dir, test_df):
     Args:
         v_name: Name with in the file contains
         gold_dir: Directory containing gold standard results
-        test_dir: Directory containing test results to be compared
+        test_df: Data frame containing test results to be compared
     Returns:
         Boolean: Whether the two images were the same
     """
@@ -71,10 +71,13 @@ class TestHRRRArchive(unittest.TestCase):
             shutil.rmtree(out_dir)
 
     def test_archive_errors(self):
-        """ Test some of the simple errors for the archive """
+        """
+        Test some of the simple errors for the archive
+        """
 
         # start end date
-        self.assertRaises(Exception, 
+        self.assertRaises(
+            Exception,
             hrrr_archive.HRRR_from_UofU,
             self.end_date,
             self.start_date,
@@ -82,7 +85,8 @@ class TestHRRRArchive(unittest.TestCase):
         )
 
         # forecasts
-        self.assertRaises(Exception, 
+        self.assertRaises(
+            Exception,
             hrrr_archive.HRRR_from_UofU,
             self.start_date,
             self.end_date,
@@ -91,7 +95,10 @@ class TestHRRRArchive(unittest.TestCase):
         )
 
     def test_download_archive(self):
-        """ Test downloading the archive data from UofU, could take around 8 minutes """
+        """
+        Test downloading the archive data from UofU.
+        Can take around 8 minutes.
+        """
 
         # get the data from the archive
         hrrr_archive.HRRR_from_UofU(

--- a/tests/test_hrrr_opendap.py
+++ b/tests/test_hrrr_opendap.py
@@ -20,7 +20,7 @@ def compare_gold(v_name, gold_dir, test_df):
     Args:
         v_name: Name with in the file contains
         gold_dir: Directory containing gold standard results
-        test_dir: Directory containing test results to be compared
+        test_df: Data frame containing test results to be compared
     Returns:
         Boolean: Whether the two images were the same
     """
@@ -77,7 +77,6 @@ class TestHRRROpendap(unittest.TestCase):
 
         self.output_path = os.path.join('tests','RME','output')
         self.gold = os.path.join('tests','RME','gold','hrrr')
-
 
     def test_load_data(self):
         """ Test loading the data from an OpenDAP THREDDS server """

--- a/tests/test_hrrr_opendap.py
+++ b/tests/test_hrrr_opendap.py
@@ -3,11 +3,14 @@
 
 """Tests for `weather_forecast_retrieval` package."""
 
-import unittest
-from weather_forecast_retrieval import hrrr
-import pandas as pd
 import os
+import unittest
 import urllib.request
+
+import numpy as np
+import pandas as pd
+
+from weather_forecast_retrieval import hrrr
 
 
 def compare_gold(v_name, gold_dir, test_df):
@@ -25,14 +28,19 @@ def compare_gold(v_name, gold_dir, test_df):
     # read in the gold standard
     fp1 = os.path.join(gold_dir, v_name+'_data.csv')
     if os.path.exists(fp1):
-        dfgold = pd.read_csv(fp1, 'r', delimiter=',', parse_dates=['date_time'], dtype=pd.np.float32)
+        dfgold = pd.read_csv(
+            fp1,
+            'r',
+            delimiter=',',
+            parse_dates=['date_time'],
+            dtype=np.float32
+        )
         dfgold.set_index('date_time', inplace=True)
 
         # see if they are the same
         # result = dfgold.equals(test_df)
 
-        return  pd.np.allclose(test_df.values,dfgold.values, atol=0)
-    
+        return np.allclose(test_df.values,dfgold.values, atol=0)
     else:
         return True
 
@@ -84,7 +92,9 @@ class TestHRRROpendap(unittest.TestCase):
 
         df = pd.read_csv(os.path.join(self.gold, 'metadata.csv'))
         df.set_index('grid', inplace=True)
-        self.assertTrue(pd.np.allclose(df.values, metadata[df.columns].values, atol=0))
+        self.assertTrue(
+            np.allclose(df.values, metadata[df.columns].values, atol=0)
+        )
 
         # compare with the gold standard
         for k, df in data.items():

--- a/tests/test_hrrr_retrieval.py
+++ b/tests/test_hrrr_retrieval.py
@@ -1,9 +1,9 @@
-import unittest
-from datetime import datetime, timedelta
-from weather_forecast_retrieval import hrrr
-import pandas as pd
 import os
 import shutil
+import unittest
+from datetime import datetime, timedelta
+
+from weather_forecast_retrieval import hrrr
 
 
 class TestHRRRRetrevial(unittest.TestCase):

--- a/tests/test_hrrr_retrieval.py
+++ b/tests/test_hrrr_retrieval.py
@@ -12,7 +12,7 @@ class TestHRRRRetrevial(unittest.TestCase):
     def setUp(self):
         self.end_date = datetime.utcnow()
         self.start_date = self.end_date - timedelta(minutes=10)
-        self.config_file = config_file = 'tests/hrrr_dates_test.ini'
+        self.config_file = 'tests/hrrr_dates_test.ini'
 
     def tearDown(self):
         """

--- a/tests/test_hrrr_retrieval.py
+++ b/tests/test_hrrr_retrieval.py
@@ -25,9 +25,10 @@ class TestHRRRRetrevial(unittest.TestCase):
         shutil.rmtree(out_path)
 
     def test_download_dates(self):
-        """ Test loading the data from an OpenDAP THREDDS server """     
+        """ Test loading the data from an OpenDAP THREDDS server """
 
         try:
-            r = hrrr.HRRR(self.config_file).retrieve_http_by_date(self.start_date, self.end_date)
+            hrrr.HRRR(self.config_file)\
+                .retrieve_http_by_date(self.start_date, self.end_date)
         except Exception as e:
             self.fail('Download failed: {}'.format(e))

--- a/weather_forecast_retrieval/grib2nc.py
+++ b/weather_forecast_retrieval/grib2nc.py
@@ -8,146 +8,145 @@ import logging
 
 
 def grib2nc(f_hrrr, output=None, external_logger=None,
-			chunk_x = 45, chunk_y = 45):
-	"""
-	Converts grib files to netcdf using HRRR forecast data and the
-	variables required by the SMRF.
-	Uses the wgrib2 command to identify variable names and uses that to filter
-	the output from the commandline.
+            chunk_x = 45, chunk_y = 45):
+    """
+    Converts grib files to netcdf using HRRR forecast data and the
+    variables required by the SMRF.
+    Uses the wgrib2 command to identify variable names and uses that to filter
+    the output from the commandline.
 
-	args:
-		f_hrrr: Path to a HRRR grib file
-		output: Path to output the resulting netcdf
-		external_logger: External logger is desired
-		chunk_x: number of chunks for the x dimension
-		chunk_y: number of chunks for the y dimension
+    args:
+        f_hrrr: Path to a HRRR grib file
+        output: Path to output the resulting netcdf
+        external_logger: External logger is desired
+        chunk_x: number of chunks for the x dimension
+        chunk_y: number of chunks for the y dimension
 
-	"""
-	start = time.time()
-	if external_logger == None:
-		fmt = "%(levelname)s: %(msg)s"
-		log = logging.getLogger(__name__)
-		coloredlogs.install(logger=log, fmt=fmt)
+    """
+    start = time.time()
+    if external_logger == None:
+        fmt = "%(levelname)s: %(msg)s"
+        log = logging.getLogger(__name__)
+        coloredlogs.install(logger=log, fmt=fmt)
 
-		msg = "GRIB2NC Converter Utility"
-		log.info(msg)
-		log.info("=" * len(msg))
+        msg = "GRIB2NC Converter Utility"
+        log.info(msg)
+        log.info("=" * len(msg))
 
-	else:
-		log = external_logger
+    else:
+        log = external_logger
 
-	log.info('Converting to netcdf: {}'.format(f_hrrr))
-	
+    log.info('Converting to netcdf: {}'.format(f_hrrr))
 
-	# criteria dictionary for extracting variables, CASE MATTERS
-	criteria = {'air_temp': {
-	            	'wgrib2 keys':[":TMP Temperature","2 m"]},
+    # criteria dictionary for extracting variables, CASE MATTERS
+    criteria = {'air_temp': {
+                    'wgrib2 keys':[":TMP Temperature","2 m"]},
 
-				'dew_point': {
-				'wgrib2 keys':[":DPT","2 m"]},
+                'dew_point': {
+                'wgrib2 keys':[":DPT","2 m"]},
 
-				'relative_humidity': {
-				'wgrib2 keys':[":RH Relative Humidity","2 m"]
-	            },
-	        'wind_u': {
-				'wgrib2 keys':[":UGRD U-Component","10 m"]
+                'relative_humidity': {
+                'wgrib2 keys':[":RH Relative Humidity","2 m"]
+                },
+            'wind_u': {
+                'wgrib2 keys':[":UGRD U-Component","10 m"]
 
-	            },
-	        'wind_v': {
-				'wgrib2 keys':[":VGRD V-Component","10 m"]
+                },
+            'wind_v': {
+                'wgrib2 keys':[":VGRD V-Component","10 m"]
 
-	            },
-	        'precip_int': {
-				'wgrib2 keys':[":APCP Total Precipitation"]
+                },
+            'precip_int': {
+                'wgrib2 keys':[":APCP Total Precipitation"]
 
-	            },
-	        'short_wave': {
-				'wgrib2 keys':['Downward Short-Wave Radiation Flux', ':surface']
-	            },
-			'elevation': {
-				'wgrib2 keys': ['Geopotential Height', ':surface']
-			}
-	        }
+                },
+            'short_wave': {
+                'wgrib2 keys':['Downward Short-Wave Radiation Flux', ':surface']
+                },
+            'elevation': {
+                'wgrib2 keys': ['Geopotential Height', ':surface']
+            }
+            }
 
-	# No output file name used, use the original plus a new extension
-	if output == None:
-		output = ".".join(os.path.basename(f_hrrr).split(".")[0:-1]) + ".nc"
-	temp_output = output + '.tmp'
+    # No output file name used, use the original plus a new extension
+    if output == None:
+        output = ".".join(os.path.basename(f_hrrr).split(".")[0:-1]) + ".nc"
+    temp_output = output + '.tmp'
 
-	grib_vars = ""
-	var_count = 0
+    grib_vars = ""
+    var_count = 0
 
-	# Cycle through all the variables and export the grib var names
-	for k,v in criteria.items():
-		log.debug("Attempting to extract grib name for {} ".format(k))
+    # Cycle through all the variables and export the grib var names
+    for k,v in criteria.items():
+        log.debug("Attempting to extract grib name for {} ".format(k))
 
-		cmd = "wgrib2 -v {} ".format(f_hrrr)
+        cmd = "wgrib2 -v {} ".format(f_hrrr)
 
-		# Add all the search filters
-		for kw in v["wgrib2 keys"]:
-			cmd += '| egrep "({})" '.format(kw)
-		# Run the command
+        # Add all the search filters
+        for kw in v["wgrib2 keys"]:
+            cmd += '| egrep "({})" '.format(kw)
+        # Run the command
 
-		#cmd += " -netcdf {}".format(output)
-		s = check_output(cmd, shell=True).decode('utf-8')
-		num_grib_var = len(s.split('\n'))
-		# Check if we only identify one variable based on line returns
-		return_count = len([True for c in s if c == '\n'])
+        #cmd += " -netcdf {}".format(output)
+        s = check_output(cmd, shell=True).decode('utf-8')
+        num_grib_var = len(s.split('\n'))
+        # Check if we only identify one variable based on line returns
+        return_count = len([True for c in s if c == '\n'])
 
-		if return_count != 1:
-			log.warning("Found multiple variable entries for keywords "
-						"associated with {}".format(k))
-			var_count += return_count
-		else:
-			var_count += 1
-		# Add the grib var name to our running string/list
-		grib_vars += s
+        if return_count != 1:
+            log.warning("Found multiple variable entries for keywords "
+                        "associated with {}".format(k))
+            var_count += return_count
+        else:
+            var_count += 1
+        # Add the grib var name to our running string/list
+        grib_vars += s
 
-	log.debug("Extracting {} variables and converting to netcdf...".format(var_count))
-	log.debug("Outputting to: {}".format(temp_output))
+    log.debug("Extracting {} variables and converting to netcdf...".format(var_count))
+    log.debug("Outputting to: {}".format(temp_output))
 
-	# Using the var names we just collected run wgrib2 for netcdf conversion
-	log.debug(grib_vars)
-	log.info("Converting grib2 to netcdf4...".format(len(grib_vars), len(cmd.split('\n'))))
-	cmd = 'echo "{}" | wgrib2 -nc4 -i {} -netcdf {}'.format(grib_vars, f_hrrr, temp_output)
-	log.debug(cmd)
-	s = check_output(cmd, shell=True)
+    # Using the var names we just collected run wgrib2 for netcdf conversion
+    log.debug(grib_vars)
+    log.info("Converting grib2 to netcdf4...".format(len(grib_vars), len(cmd.split('\n'))))
+    cmd = 'echo "{}" | wgrib2 -nc4 -i {} -netcdf {}'.format(grib_vars, f_hrrr, temp_output)
+    log.debug(cmd)
+    s = check_output(cmd, shell=True)
 
-	# Recast dimensions
-	log.info("Reducing dimensional variables to type ints and floats.")
+    # Recast dimensions
+    log.info("Reducing dimensional variables to type ints and floats.")
 
-	cmd = "ncap2 -O -s 'latitude=float(latitude);longitude=float(longitude);x=int(x);y=int(y);time=int(time)' {0} {0}".format(temp_output)
-	log.debug(cmd)
-	s = check_output(cmd, shell=True)
+    cmd = "ncap2 -O -s 'latitude=float(latitude);longitude=float(longitude);x=int(x);y=int(y);time=int(time)' {0} {0}".format(temp_output)
+    log.debug(cmd)
+    s = check_output(cmd, shell=True)
 
-	# Add chunking
-	log.info("Adding chunking")
-	cmd = "nccopy -w -c time/1,x/{},y/{} {} {}".format(chunk_x, chunk_y, temp_output, output)
-	log.debug(cmd)
-	s = check_output(cmd, shell=True)
+    # Add chunking
+    log.info("Adding chunking")
+    cmd = "nccopy -w -c time/1,x/{},y/{} {} {}".format(chunk_x, chunk_y, temp_output, output)
+    log.debug(cmd)
+    s = check_output(cmd, shell=True)
 
-	# clean up the temp file
-	os.remove(temp_output)
-	
-	log.info("Complete! Elapsed {:0.0f}s".format(time.time()-start))
+    # clean up the temp file
+    os.remove(temp_output)
+
+    log.info("Complete! Elapsed {:0.0f}s".format(time.time()-start))
 
 
 def main():
-	p = argparse.ArgumentParser(description="Command line tool for converting"
-								" HRRR grib files to netcdf using only the "
-								" variables we want.")
+    p = argparse.ArgumentParser(description="Command line tool for converting"
+                                " HRRR grib files to netcdf using only the "
+                                " variables we want.")
 
-	p.add_argument(dest="hrrr", help="Path to the HRRR file containing the"
-	 								 " variables for SMRF")
-	p.add_argument("-o", "--output", dest="output", required=False,
-												default=None,
-	            								help="Path to output the netcdf"
-												" file if you don't want it"
-												" renamed the same as the hrrr"
-												" file with a different"
-												" extension.")
-	args = p.parse_args()
-	grib2nc(args.hrrr, args.output)
+    p.add_argument(dest="hrrr", help="Path to the HRRR file containing the"
+                                     " variables for SMRF")
+    p.add_argument("-o", "--output", dest="output", required=False,
+                                                default=None,
+                                                help="Path to output the netcdf"
+                                                " file if you don't want it"
+                                                " renamed the same as the hrrr"
+                                                " file with a different"
+                                                " extension.")
+    args = p.parse_args()
+    grib2nc(args.hrrr, args.output)
 
 if __name__ == "__main__":
-	main()
+    main()

--- a/weather_forecast_retrieval/grib2nc.py
+++ b/weather_forecast_retrieval/grib2nc.py
@@ -1,21 +1,20 @@
-import os
-import sys
-from subprocess import check_output
 import argparse
-import time
-import coloredlogs
 import logging
+import os
+import time
+from subprocess import check_output
+
+import coloredlogs
 
 
-def grib2nc(f_hrrr, output=None, external_logger=None,
-            chunk_x = 45, chunk_y = 45):
+def grib2nc(f_hrrr, output=None, external_logger=None, chunk_x=45, chunk_y=45):
     """
     Converts grib files to netcdf using HRRR forecast data and the
     variables required by the SMRF.
     Uses the wgrib2 command to identify variable names and uses that to filter
     the output from the commandline.
 
-    args:
+    Args:
         f_hrrr: Path to a HRRR grib file
         output: Path to output the resulting netcdf
         external_logger: External logger is desired
@@ -24,7 +23,8 @@ def grib2nc(f_hrrr, output=None, external_logger=None,
 
     """
     start = time.time()
-    if external_logger == None:
+
+    if external_logger is None:
         fmt = "%(levelname)s: %(msg)s"
         log = logging.getLogger(__name__)
         coloredlogs.install(logger=log, fmt=fmt)
@@ -32,44 +32,41 @@ def grib2nc(f_hrrr, output=None, external_logger=None,
         msg = "GRIB2NC Converter Utility"
         log.info(msg)
         log.info("=" * len(msg))
-
     else:
         log = external_logger
 
     log.info('Converting to netcdf: {}'.format(f_hrrr))
 
     # criteria dictionary for extracting variables, CASE MATTERS
-    criteria = {'air_temp': {
-                    'wgrib2 keys':[":TMP Temperature","2 m"]},
-
-                'dew_point': {
-                'wgrib2 keys':[":DPT","2 m"]},
-
-                'relative_humidity': {
-                'wgrib2 keys':[":RH Relative Humidity","2 m"]
-                },
-            'wind_u': {
-                'wgrib2 keys':[":UGRD U-Component","10 m"]
-
-                },
-            'wind_v': {
-                'wgrib2 keys':[":VGRD V-Component","10 m"]
-
-                },
-            'precip_int': {
-                'wgrib2 keys':[":APCP Total Precipitation"]
-
-                },
-            'short_wave': {
-                'wgrib2 keys':['Downward Short-Wave Radiation Flux', ':surface']
-                },
-            'elevation': {
-                'wgrib2 keys': ['Geopotential Height', ':surface']
-            }
-            }
+    criteria = {
+        'air_temp': {
+            'wgrib2 keys': [":TMP Temperature", "2 m"]
+        },
+        'dew_point': {
+            'wgrib2 keys': [":DPT", "2 m"]
+        },
+        'relative_humidity': {
+            'wgrib2 keys': [":RH Relative Humidity", "2 m"]
+        },
+        'wind_u': {
+            'wgrib2 keys': [":UGRD U-Component", "10 m"]
+        },
+        'wind_v': {
+            'wgrib2 keys': [":VGRD V-Component", "10 m"]
+        },
+        'precip_int': {
+            'wgrib2 keys': [":APCP Total Precipitation"]
+        },
+        'short_wave': {
+            'wgrib2 keys': ['Downward Short-Wave Radiation Flux', ':surface']
+        },
+        'elevation': {
+            'wgrib2 keys': ['Geopotential Height', ':surface']
+        }
+    }
 
     # No output file name used, use the original plus a new extension
-    if output == None:
+    if output is None:
         output = ".".join(os.path.basename(f_hrrr).split(".")[0:-1]) + ".nc"
     temp_output = output + '.tmp'
 
@@ -136,17 +133,19 @@ def main():
                                 " HRRR grib files to netcdf using only the "
                                 " variables we want.")
 
-    p.add_argument(dest="hrrr", help="Path to the HRRR file containing the"
-                                     " variables for SMRF")
-    p.add_argument("-o", "--output", dest="output", required=False,
-                                                default=None,
-                                                help="Path to output the netcdf"
-                                                " file if you don't want it"
-                                                " renamed the same as the hrrr"
-                                                " file with a different"
-                                                " extension.")
+    p.add_argument(dest="hrrr",
+                   help="Path to the HRRR file containing the variables "
+                        "for SMRF")
+    p.add_argument("-o", "--output",
+                   dest="output",
+                   required=False,
+                   default=None,
+                   help="Path to output the netcdf file if you don't want it "
+                        "renamed the same as the hrrr file with a different "
+                        "extension.")
     args = p.parse_args()
     grib2nc(args.hrrr, args.output)
+
 
 if __name__ == "__main__":
     main()

--- a/weather_forecast_retrieval/hrrr.py
+++ b/weather_forecast_retrieval/hrrr.py
@@ -2,23 +2,24 @@
 Connect to the HRRR site and download the data
 """
 
-from ftplib import FTP
-import os, fnmatch
-import logging
-from logging.handlers import TimedRotatingFileHandler
-from datetime import datetime, timedelta, time
-import pandas as pd
-import utm
 import copy
-from bs4 import BeautifulSoup
-import requests
+import fnmatch
+import logging
+import os
 import re
-from siphon.catalog import TDSCatalog
-import xarray as xr
+from datetime import datetime, timedelta, time
+from ftplib import FTP
+from logging.handlers import TimedRotatingFileHandler
 from multiprocessing.pool import ThreadPool
 
-from weather_forecast_retrieval import hrrr_archive
-from weather_forecast_retrieval import utils
+import pandas as pd
+import requests
+import utm
+import xarray as xr
+from bs4 import BeautifulSoup
+from siphon.catalog import TDSCatalog
+
+from weather_forecast_retrieval import hrrr_archive, utils
 
 
 class HRRR:

--- a/weather_forecast_retrieval/hrrr.py
+++ b/weather_forecast_retrieval/hrrr.py
@@ -12,6 +12,7 @@ from ftplib import FTP
 from logging.handlers import TimedRotatingFileHandler
 from multiprocessing.pool import ThreadPool
 
+import numpy as np
 import pandas as pd
 import requests
 import utm
@@ -703,15 +704,15 @@ class HRRR:
                 # remove some coordinate so they can all be combined into one dataset
                 for v in ['heightAboveGround', 'surface']:
                     if v in data.coords.keys():
-                        data = data.drop(v)
+                        data = data.drop_vars(v)
 
                 # make the time an index coordinate
                 data = data.assign_coords(time=data['valid_time'])
                 data = data.expand_dims('time')
 
                 # have to set the x and y coordinates based on the 3000 meter cell size
-                data = data.assign_coords(x=pd.np.arange(0, len(data['x'])) * 3000)
-                data = data.assign_coords(y=pd.np.arange(0, len(data['y'])) * 3000)
+                data = data.assign_coords(x=np.arange(0, len(data['x'])) * 3000)
+                data = data.assign_coords(y=np.arange(0, len(data['y'])) * 3000)
 
                 # delete the step and valid time coordinates
                 del data['step']

--- a/weather_forecast_retrieval/hrrr.py
+++ b/weather_forecast_retrieval/hrrr.py
@@ -21,7 +21,7 @@ from weather_forecast_retrieval import hrrr_archive
 from weather_forecast_retrieval import utils
 
 
-class HRRR():
+class HRRR:
     """
     The High Resolution Rapid Refresh (HRRR) model is a NOAA
     real-time 3 km resolution forecast. The model output is updated
@@ -134,7 +134,7 @@ class HRRR():
                 self.request_timeout = int(self.config['output']['request_timeout'])
 
         # start logging
-        if external_logger == None:
+        if external_logger is None:
 
             # setup the logging
             if configFile is not None:
@@ -667,7 +667,6 @@ class HRRR():
 
             return False
 
-
     def get_one_grib(self, fp, new_var_map, dt):
         """
         Get valid HRRR data using xarray
@@ -738,7 +737,6 @@ class HRRR():
                 success = False
 
         return success
-
 
     def check_file_health(self, output_dir, start_date, end_date,
                           hours=range(23), forecasts=range(18), min_size=100):

--- a/weather_forecast_retrieval/hrrr_archive.py
+++ b/weather_forecast_retrieval/hrrr_archive.py
@@ -185,7 +185,7 @@ def HRRR_from_UofU(start_date, end_date, save_dir, external_logger=None,
     if start_date >= end_date:
         logger.error('Start date is before end date')
         raise Exception('Start date is before end date')
-    
+
     if not isinstance(forecasts, range):
         if not isinstance(forecasts, list):
             logger.error('forecasts must be a list or range')

--- a/weather_forecast_retrieval/hrrr_archive.py
+++ b/weather_forecast_retrieval/hrrr_archive.py
@@ -16,15 +16,16 @@ http://hrrr.chpc.utah.edu/
 
 """
 
-from datetime import date, datetime, timedelta
 import argparse
 import logging
-import coloredlogs
-import time
 import os
+import time
+from datetime import datetime
+
+import coloredlogs
+import pandas as pd
 import pytz
 import requests
-import pandas as pd
 
 # times when downloading should stop as recomended by U of U
 tzmdt = pytz.timezone('America/Denver')


### PR DESCRIPTION
This looks like a lot of changes and they pretty much repeat throughout the files:
* Organize imports to have standard libraries first, then third-party, and then internal (https://code.google.com/archive/p/soc/wikis/PythonStyleGuide.wiki)
* Change comparison with `None` to `is` instead of `==`
* Add `numpy` as dependency, which address deprecation warning of `pandas` to not reference `pd.np`
* Replaced `xarray` `drop` with `drop_var`
* Update some outdated doc strings
* Use spaces instead of tabs

All tests pass.