### PR TITLE
Requirements - remove pyproj

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 pyyaml==4.2b1
 coloredlogs==6.1
 siphon>=0.6.1
-pyproj>=1.9.5.1,<2.0
 utm==0.4.0
 pytz
 requests>=2.21.0


### PR DESCRIPTION
Library is not referenced in code and most likely a relic from an old
dependency that is no longer in place.