### PR TITLE
Requirements - Restrict Xarray to version 0.15.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ utm==0.4.0
 pytz
 requests>=2.21.0
 netCDF4>=1.5.1.2
-xarray>=0.15.0
+xarray>=0.15,<0.16
 cfgrib>=0.9.7.1
 beautifulsoup4
 pandas


### PR DESCRIPTION
Xarray version 0.16.0 will cause an error when trying to read out GRIB
files.

Sample error raised when using this version:
```
Merging {'GRIB_edition': 2, 'GRIB_centre': 'kwbc', 'GRIB_centreDescription': 'US National Weather Service - NCEP ', 'GRIB_subCentre': 0, 'Conventions': 'CF-1.7', 'institution': 'US National Weather Service - NCEP ', 'history': '2020-10-09T14:49:54 GRIB to CDM+CF via cfgrib-0.9.8.4/ecCodes-2.18.0 with {"source": "/data/iSnobal/HRRR_CBR/hrrr.20180201/hrrr.t23z.wrfsfcf01.grib2", "filter_by_keys": {"level": 2, "typeOfLevel": "heightAboveGround", "cfName": "air_temperature", "cfVarName": "t2m"}, "encode_cf": ["parameter", "time", "geography", "vertical"]}'} with {'GRIB_edition': 2, 'GRIB_centre': 'kwbc', 'GRIB_centreDescription': 'US National Weather Service - NCEP ', 'GRIB_subCentre': 0, 'Conventions': 'CF-1.7', 'institution': 'US National Weather Service - NCEP ', 'history': '2020-10-09T14:49:54 GRIB to CDM+CF via cfgrib-0.9.8.4/ecCodes-2.18.0 with {"source": "/data/iSnobal/HRRR_CBR/hrrr.20180201/hrrr.t23z.wrfsfcf01.grib2", "filter_by_keys": {"level": 0, "typeOfLevel": "surface", "stepType": "instant", "cfVarName": "dswrf"}, "encode_cf": ["parameter", "time", "geography", "vertical"]}'}
```