### PR TITLE
GRRIB file reading updates

### DIFF
--- a/weather_forecast_retrieval/data/hrrr/file_loader.py
+++ b/weather_forecast_retrieval/data/hrrr/file_loader.py
@@ -236,8 +236,6 @@ class FileLoader(ConfigFile):
                     metadata.append(dftmp)
 
                 metadata = pd.concat(metadata, axis=1)
-                # it's reporting in degrees from the east
-                metadata['longitude'] -= 360
                 metadata = metadata.apply(
                     FileLoader.apply_utm,
                     args=(self.force_zone_number,),
@@ -280,8 +278,12 @@ class FileLoader(ConfigFile):
         Returns:
             Pandas series entry with fields 'utm_x' and 'utm_y' filled
         """
+        # HRRR has longitude reporting in degrees from the east
+        dataframe['longitude'] -= 360
+
         (dataframe['utm_x'], dataframe['utm_y'], *unused) = utm.from_latlon(
-            dataframe.latitude, dataframe.longitude,
+            dataframe['latitude'],
+            dataframe['longitude'],
             force_zone_number=force_zone_number
         )
 

--- a/weather_forecast_retrieval/data/hrrr/file_loader.py
+++ b/weather_forecast_retrieval/data/hrrr/file_loader.py
@@ -228,9 +228,7 @@ class FileLoader(ConfigFile):
                 metadata = []
                 for mm in ['latitude', 'longitude', value]:
                     dftmp = df[mm].copy()
-                    cols = ['grid_{}_{}'.format(x[0], x[1])
-                            for x in dftmp.columns.to_flat_index()]
-                    dftmp.columns = cols
+                    dftmp.columns = self.format_column_names(dftmp)
                     dftmp = dftmp.iloc[0]
                     dftmp.name = mm
                     metadata.append(dftmp)
@@ -244,16 +242,11 @@ class FileLoader(ConfigFile):
                 metadata.rename(columns={value: key}, inplace=True)
 
             else:
-                # else this is just a normal variable
                 df = df.loc[:, key]
 
-                # make new names for the columns as grid_y_x
-                cols = ['grid_{}_{}'.format(x[0], x[1])
-                        for x in df.columns.to_flat_index()]
-                df.columns = cols
+                df.columns = self.format_column_names(df)
                 df.index.rename('date_time', inplace=True)
 
-                # drop any nan values
                 df.dropna(axis=1, how='all', inplace=True)
                 dataframe[key] = df
 
@@ -265,6 +258,20 @@ class FileLoader(ConfigFile):
         metadata = metadata[metadata.index.isin(list(set(c)))]
 
         return metadata, dataframe
+
+    @staticmethod
+    def format_column_names(dataframe):
+        """
+        Make new names for the columns as grid_y_x
+
+        :param dataframe:
+        :return: Array - New column names including the y and x GRIB pixel
+                         index. Example: grid_0_1 for y at 0 and x at 1
+        """
+        return [
+            'grid_{c[0]}_{c[1]}'.format(c=col)
+            for col in dataframe.columns.to_flat_index()
+        ]
 
     @staticmethod
     def apply_utm(dataframe, force_zone_number):

--- a/weather_forecast_retrieval/data/hrrr/grib_file.py
+++ b/weather_forecast_retrieval/data/hrrr/grib_file.py
@@ -1,4 +1,3 @@
-import numpy as np
 import xarray as xr
 
 from weather_forecast_retrieval.data.hrrr.base_file import BaseFile

--- a/weather_forecast_retrieval/data/hrrr/grib_file.py
+++ b/weather_forecast_retrieval/data/hrrr/grib_file.py
@@ -80,7 +80,10 @@ class GribFile(BaseFile):
             data = xr.open_dataset(
                 file,
                 engine='cfgrib',
-                backend_kwargs={'filter_by_keys': params}
+                backend_kwargs={
+                    'filter_by_keys': params,
+                    'indexpath': '',
+                }
             )
 
             if len(data) > 1:

--- a/weather_forecast_retrieval/data/hrrr/grib_file.py
+++ b/weather_forecast_retrieval/data/hrrr/grib_file.py
@@ -9,48 +9,60 @@ class GribFile(BaseFile):
 
     CELL_SIZE = 3000  # in meters
 
-    # dataset filter by keys arguments
-    VAR_MAP = {
-        'air_temp': {
-            'level': 2,
-            'typeOfLevel': 'heightAboveGround',
-            'cfName': 'air_temperature',
-            'cfVarName': 't2m'
-        },
-        'relative_humidity': {
-            'level': 2,
-            'typeOfLevel': 'heightAboveGround',
-            # 'parameterName': 'Relative humidity',
-            'cfVarName': 'r2'
-        },
-        'wind_u': {
-            'level': 10,
-            'typeOfLevel': 'heightAboveGround',
-            # 'parameterName': 'u-component of wind',
-            'cfVarName': 'u10'
-        },
-        'wind_v': {
-            'level': 10,
-            'typeOfLevel': 'heightAboveGround',
-            # 'parameterName': 'v-component of wind',
-            'cfVarName': 'v10'
-        },
+    SURFACE = {
+        'level': 0,
+        'typeOfLevel': 'surface',
+    }
+    SURFACE_VARIABLES = {
         'precip_int': {
-            'level': 0,
-            'typeOfLevel': 'surface',
             'name': 'Total Precipitation',
-            'shortName': 'tp'
+            'shortName': 'tp',
+            **SURFACE,
         },
         'short_wave': {
-            'level': 0,
-            'typeOfLevel': 'surface',
             'stepType': 'instant',
-            'cfVarName': 'dswrf'
+            'cfVarName': 'dswrf',
+            **SURFACE,
         },
         'elevation': {
-            'typeOfLevel': 'surface',
-            'cfVarName': 'orog'
+            'cfVarName': 'orog',
+            **SURFACE,
         }
+    }
+    # HAG - Height Above Ground
+    HAG_2 = {
+        'level': 2,
+        'typeOfLevel': 'heightAboveGround',
+    }
+    HAG_2_VARIABLES = {
+        'air_temp': {
+            'cfName': 'air_temperature',
+            'cfVarName': 't2m',
+            **HAG_2,
+        },
+        'relative_humidity': {
+            'cfVarName': 'r2',
+            **HAG_2,
+        },
+    }
+    HAG_10 = {
+        'level': 10,
+        'typeOfLevel': 'heightAboveGround',
+    }
+    HAG_10_VARIABLES = {
+        'wind_u': {
+            'cfVarName': 'u10',
+            **HAG_10,
+        },
+        'wind_v': {
+            'cfVarName': 'v10',
+            **HAG_10,
+        },
+    }
+    VAR_MAP = {
+        **SURFACE_VARIABLES,
+        **HAG_2_VARIABLES,
+        **HAG_10_VARIABLES,
     }
 
     def __init__(self, config_file=None, external_logger=None):

--- a/weather_forecast_retrieval/data/hrrr/grib_file.py
+++ b/weather_forecast_retrieval/data/hrrr/grib_file.py
@@ -130,14 +130,8 @@ class GribFile(BaseFile):
             variable = params.get('cfVarName') or params.get('shortName')
             data = data.rename({variable: key})
 
-            # Set the x and y coordinates based on the cell size
-            data = data.assign_coords(
-                time=data['valid_time'],
-                x=np.arange(0, len(data['x'])) * self.CELL_SIZE,
-                y=np.arange(0, len(data['y'])) * self.CELL_SIZE
-            )
-
             # Make the time an index coordinate
+            data = data.assign_coords(time=data['valid_time'])
             data = data.expand_dims('time')
             del data['valid_time']
 


### PR DESCRIPTION
Found a few improvements when reading GRIB files with Xarray and how the dataframe conversion is done later.

The changes:
* Separate the VAR_MAP into groups. This is mainly for readability.
* First filter the read GRIB file to area of interest before manipulating Xarray dimensions and indices.
* Don't create *.idx files when reading GRIB files. These are not used currently.
* Remove scaling the X and Y by GRIB cell size (see below for reasoning).
* Extract method that renames the dataframe columns.
* Consolidate coordinate conversions from lat/lon to UTM into one method.

I removed the scaling for the X and Y as I did not see any use of that info at a later place. Dropping and adding indices is a relatively expensive operation. If there is still a need to have that information with the dataframe columns, it could be added back in when renaming the columns.