### PR TITLE
Expose library structure via API

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,9 @@ inline-quotes = single
 multiline-quotes = double
 rst-roles = class, data, func, meth, mod
 docstring-convention = numpy
+per-file-ignores =
+# imported but unused
+    __init__.py: F401
 
 [coverage:run]
 omit =

--- a/tests/data/hrrr/test_grib_file.py
+++ b/tests/data/hrrr/test_grib_file.py
@@ -28,3 +28,9 @@ class TestGribFile(unittest.TestCase):
 
     def test_cell_size(self):
         self.assertEqual(3000, GribFile.CELL_SIZE)
+
+    def test_variables(self):
+        self.assertEqual(
+            GribFile.VAR_MAP.keys(),
+            GribFile.VARIABLES
+        )

--- a/weather_forecast_retrieval/__init__.py
+++ b/weather_forecast_retrieval/__init__.py
@@ -5,4 +5,4 @@ try:
 except DistributionNotFound:
     __version__ = 'unknown'
 
-import weather_forecast_retrieval.data # noqa
+import weather_forecast_retrieval.data

--- a/weather_forecast_retrieval/__init__.py
+++ b/weather_forecast_retrieval/__init__.py
@@ -4,3 +4,5 @@ try:
     __version__ = get_distribution(__name__).version
 except DistributionNotFound:
     __version__ = 'unknown'
+
+import weather_forecast_retrieval.data # noqa

--- a/weather_forecast_retrieval/data/__init__.py
+++ b/weather_forecast_retrieval/data/__init__.py
@@ -1,0 +1,1 @@
+import weather_forecast_retrieval.data.hrrr # noqa

--- a/weather_forecast_retrieval/data/__init__.py
+++ b/weather_forecast_retrieval/data/__init__.py
@@ -1,1 +1,1 @@
-import weather_forecast_retrieval.data.hrrr # noqa
+import weather_forecast_retrieval.data.hrrr

--- a/weather_forecast_retrieval/data/hrrr/__init__.py
+++ b/weather_forecast_retrieval/data/hrrr/__init__.py
@@ -1,11 +1,13 @@
 from .file_handler import FileHandler
 from .file_loader import FileLoader
 from .ftp_retrieval import FtpRetrieval
+from .grib_file import GribFile
 from .http_retrieval import HttpRetrieval
 
 __all__ = [
     FileHandler,
+    FileLoader,
     FtpRetrieval,
+    GribFile,
     HttpRetrieval,
-    FileLoader
 ]

--- a/weather_forecast_retrieval/data/hrrr/grib_file.py
+++ b/weather_forecast_retrieval/data/hrrr/grib_file.py
@@ -4,6 +4,12 @@ from weather_forecast_retrieval.data.hrrr.base_file import BaseFile
 
 
 class GribFile(BaseFile):
+    """
+    Class to load a GRIB2 file from disk.
+
+    The VAR_MAP class constants holds a mapping for currently available
+    variables that are loadable from a file.
+    """
     SUFFIX = 'grib2'
 
     CELL_SIZE = 3000  # in meters
@@ -63,6 +69,7 @@ class GribFile(BaseFile):
         **HAG_2_VARIABLES,
         **HAG_10_VARIABLES,
     }
+    VARIABLES = VAR_MAP.keys()
 
     def __init__(self, config=None, external_logger=None):
         super().__init__(


### PR DESCRIPTION
This sets up the library to allow imports such as:
```python
import weather_forecast_retrieval as wfr
```
and then use relative references based of the alias.

Also exposes the variables as a list for outside references.